### PR TITLE
CT-88

### DIFF
--- a/app/src/main/java/br/com/connectattoo/ui/registration/UserRegistration.kt
+++ b/app/src/main/java/br/com/connectattoo/ui/registration/UserRegistration.kt
@@ -268,7 +268,7 @@ abstract class UserRegistration<T : ViewBinding> : BaseFragment<T>() {
 
     companion object {
         const val MIN_PASSWORD_LENGTH = 8
-        const val HAS_SPECIAL_SYMBOL = "^(?=.*[_.*=!%()$&@+-/]).*$"
+        const val HAS_SPECIAL_SYMBOL = "^(?=.*[_.*=!%()$&@+-/#]).*$"
         const val HAS_UPPER_CASE = ".*[A-Z].*"
         const val HAS_LOWER_CASE = ".*[a-z].*"
         const val HAS_NUMBER = ".*[0-9].*"


### PR DESCRIPTION
## Correção no bug que não reconhecia # como caractere especial no campo de senha:

#### - Atualizada a varíavel HAS_SPECIAL_SYMBOL, da classe abstrata UserRegistration, incluindo o # e corrigindo o erro