### PR TITLE
CT-22/CT-129

### DIFF
--- a/app/src/main/java/br/com/connectattoo/api/response/TattooClientProfileResponse.kt
+++ b/app/src/main/java/br/com/connectattoo/api/response/TattooClientProfileResponse.kt
@@ -9,7 +9,8 @@ data class TattooClientProfileResponse(
     val username: String? = "",
     val birthDate: String? = "",
     val imageProfile: String? = "",
-    val tags: List<Tag> = emptyList()
+    val tags: List<Tag> = emptyList(),
+    val email: String? = ""
 ) {
     fun toTattooClientProfileEntity(): TattooClientProfileEntity {
         return TattooClientProfileEntity(
@@ -17,7 +18,8 @@ data class TattooClientProfileResponse(
             username = this.username ?: "",
             birthDate = this.birthDate ?: "",
             imageProfile = this.imageProfile ?: "",
-            tags = this.tags.toTagEntity()
+            tags = this.tags.toTagEntity(),
+            email = this.email
         )
     }
 }

--- a/app/src/main/java/br/com/connectattoo/data/TattooClientProfile.kt
+++ b/app/src/main/java/br/com/connectattoo/data/TattooClientProfile.kt
@@ -5,5 +5,6 @@ data class TattooClientProfile(
     val username: String? = "",
     val birthDate: String? = "",
     val imageProfile: String? = "",
-    val tags: List<Tag> = emptyList()
+    val tags: List<Tag> = emptyList(),
+    val email: String? = ""
 )

--- a/app/src/main/java/br/com/connectattoo/local/database/entity/TattooClientProfileEntity.kt
+++ b/app/src/main/java/br/com/connectattoo/local/database/entity/TattooClientProfileEntity.kt
@@ -15,7 +15,8 @@ data class TattooClientProfileEntity(
     @ColumnInfo(name = "user_name") val username: String? = "",
     @ColumnInfo(name = "birth_date") val birthDate: String? = "",
     @ColumnInfo(name = "image_profile") val imageProfile: String? = "",
-    var tags: List<TagEntity> = emptyList()
+    var tags: List<TagEntity> = emptyList(),
+    val email: String? = ""
 ) {
 
     fun toTattooClientProfile(): TattooClientProfile =
@@ -24,7 +25,8 @@ data class TattooClientProfileEntity(
             username = this.username ?: "",
             birthDate = this.birthDate ?: "",
             imageProfile = this.imageProfile ?: "",
-            tags = this.tags.toTag()
+            tags = this.tags.toTag(),
+            email = this.email
         )
 
 }

--- a/app/src/main/java/br/com/connectattoo/ui/home/HomeUserState.kt
+++ b/app/src/main/java/br/com/connectattoo/ui/home/HomeUserState.kt
@@ -8,5 +8,6 @@ data class HomeUserState(
     val birthDate: String? = "",
     val imageProfile: String? = "",
     val stateError: String? = "",
-    val tags: List<Tag>? = emptyList()
+    val tags: List<Tag>? = emptyList(),
+    val email: String? = "",
 )

--- a/app/src/main/java/br/com/connectattoo/ui/home/HomeUserViewModel.kt
+++ b/app/src/main/java/br/com/connectattoo/ui/home/HomeUserViewModel.kt
@@ -1,6 +1,5 @@
 package br.com.connectattoo.ui.home
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import br.com.connectattoo.repository.ProfileRepository
@@ -8,7 +7,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
-class HomeUserViewModel: ViewModel() {
+class HomeUserViewModel : ViewModel() {
 
     private var _state: HomeUserState = HomeUserState()
     val state: HomeUserState get() = _state
@@ -16,32 +15,33 @@ class HomeUserViewModel: ViewModel() {
     private val _uiStateFlow = MutableStateFlow<UiState>(UiState.Initial)
     val uiStateFlow: StateFlow<UiState> get() = _uiStateFlow
 
-    fun getClientProfile(profileRepository: ProfileRepository, token: String){
+    fun getClientProfile(profileRepository: ProfileRepository, token: String) {
 
         viewModelScope.launch {
             _uiStateFlow.value = UiState.Loading
             val result = profileRepository.getProfileUser(token)
 
             result.collect {
-                if (it.error != null){
+                if (it.error != null) {
                     _state = _state.copy(stateError = it.error?.message.toString())
                     _uiStateFlow.value = UiState.Error
                 }
-                it.data?.let {clientProfile ->
+                it.data?.let { clientProfile ->
                     val firstName = clientProfile.displayName?.split(" ")?.get(0)
                     _state = _state.copy(
                         displayName = firstName,
                         username = clientProfile.username,
                         birthDate = clientProfile.birthDate,
                         imageProfile = clientProfile.imageProfile,
-                        tags = clientProfile.tags
+                        tags = clientProfile.tags,
+                        email = clientProfile.email
                     )
-                    Log.i("tagsl", _state.tags.toString())
                     _uiStateFlow.value = UiState.Success
                 }
             }
         }
     }
+
     sealed class UiState {
         data object Success : UiState()
         data object Error : UiState()


### PR DESCRIPTION
### Alterar estrutura da resposta da API para perfil

- Alterada a estrutura da resposta da API em TattooClientProfileResponse e demais para adição da propriedade de email.
- Verificado o fluxo do código e realizada a alteração onde havia a propriedade de email.
- Persistido na base de dados local.