### PR TITLE
CT-32/CT-127

### DIFF
--- a/app/src/main/java/br/com/connectattoo/api/ApiService.kt
+++ b/app/src/main/java/br/com/connectattoo/api/ApiService.kt
@@ -2,7 +2,6 @@ package br.com.connectattoo.api
 
 import br.com.connectattoo.api.response.ApiConfirmationResponse
 import br.com.connectattoo.api.response.TattooClientProfileResponse
-import br.com.connectattoo.core.ResourceResult
 import br.com.connectattoo.data.ArtistData
 import br.com.connectattoo.data.ClientData
 import br.com.connectattoo.data.TokenData

--- a/app/src/main/java/br/com/connectattoo/api/ApiService.kt
+++ b/app/src/main/java/br/com/connectattoo/api/ApiService.kt
@@ -2,12 +2,14 @@ package br.com.connectattoo.api
 
 import br.com.connectattoo.api.response.ApiConfirmationResponse
 import br.com.connectattoo.api.response.TattooClientProfileResponse
+import br.com.connectattoo.core.ResourceResult
 import br.com.connectattoo.data.ArtistData
 import br.com.connectattoo.data.ClientData
 import br.com.connectattoo.data.TokenData
 import retrofit2.Call
 import retrofit2.Response
 import retrofit2.http.Body
+import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.Header
 import retrofit2.http.Headers
@@ -33,4 +35,8 @@ interface ApiService {
         @Header("Authorization") authorization: String
     ): Response<TattooClientProfileResponse>
 
+    @DELETE("profile/me/image")
+    suspend fun deleteProfilePhoto(
+        @Header("Authorization") authorization: String
+    ): Response<String>
 }

--- a/app/src/main/java/br/com/connectattoo/api/ApiService.kt
+++ b/app/src/main/java/br/com/connectattoo/api/ApiService.kt
@@ -37,5 +37,5 @@ interface ApiService {
     @DELETE("profile/me/image")
     suspend fun deleteProfilePhoto(
         @Header("Authorization") authorization: String
-    ): Response<String>
+    ): Response<Unit>
 }

--- a/app/src/main/java/br/com/connectattoo/local/database/dao/TattooClientProfileDao.kt
+++ b/app/src/main/java/br/com/connectattoo/local/database/dao/TattooClientProfileDao.kt
@@ -14,9 +14,9 @@ interface TattooClientProfileDao {
     suspend fun getTattooClientProfile(): TattooClientProfileEntity?
 
     @Query("DELETE FROM profile")
-    suspend fun dellTattooClientProfile()
+    suspend fun deleteTattooClientProfile()
 
-    @Query("UPDATE profile SET image_profile = '' WHERE id = :id")
-    suspend fun dellTattooClientProfilePhoto(id: Long)
+    @Query("UPDATE profile SET image_profile = :profilePhoto WHERE id = :id")
+    suspend fun updateTattooClientProfilePhoto(id: Long, profilePhoto: String?)
 
 }

--- a/app/src/main/java/br/com/connectattoo/local/database/dao/TattooClientProfileDao.kt
+++ b/app/src/main/java/br/com/connectattoo/local/database/dao/TattooClientProfileDao.kt
@@ -16,4 +16,7 @@ interface TattooClientProfileDao {
     @Query("DELETE FROM profile")
     suspend fun dellTattooClientProfile()
 
+    @Query("UPDATE profile SET image_profile = '' WHERE id = :id")
+    suspend fun dellTattooClientProfilePhoto(id: Long)
+
 }

--- a/app/src/main/java/br/com/connectattoo/repository/ProfileRepository.kt
+++ b/app/src/main/java/br/com/connectattoo/repository/ProfileRepository.kt
@@ -8,7 +8,7 @@ import br.com.connectattoo.core.MessageException
 import br.com.connectattoo.core.ResourceResult
 import br.com.connectattoo.data.TattooClientProfile
 import br.com.connectattoo.local.database.dao.TattooClientProfileDao
-import br.com.connectattoo.util.Constants.CODE_SUCCESS_204
+import br.com.connectattoo.util.Constants.CODE_SUCCESS_200
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import retrofit2.Response
@@ -27,7 +27,7 @@ class ProfileRepository(private val tattooClientProfileDao: TattooClientProfileD
             with(apiService.getProfileUser(token)) {
                 val clientProfile = this.body()
                 if (this.isSuccessful && clientProfile != null) {
-                    tattooClientProfileDao.dellTattooClientProfile()
+                    tattooClientProfileDao.deleteTattooClientProfile()
                     tattooClientProfileDao.insertTattooClientProfile(clientProfile.toTattooClientProfileEntity())
                 }
                 data = tattooClientProfileDao.getTattooClientProfile()
@@ -39,7 +39,6 @@ class ProfileRepository(private val tattooClientProfileDao: TattooClientProfileD
         }
         return (ResourceResult.Success(data?.toTattooClientProfile()))
     }
-
 
     fun getClientProfileRoom(): Flow<ResourceResult<TattooClientProfile>> = flow {
         try {
@@ -59,25 +58,23 @@ class ProfileRepository(private val tattooClientProfileDao: TattooClientProfileD
     fun deleteProfilePhoto(token: String): Flow<ResourceResult<String>> = flow {
         emit(deleteProfilePhotoAPIAndRoom("Bearer $token"))
     }
-    private suspend fun deleteProfilePhotoAPIAndRoom(token: String): ResourceResult<String> {
-        try {
-            with(apiService.deleteProfilePhoto(token)) {
-                return resourceResultDeleteProfilePhoto()
-            }
 
+    private suspend fun deleteProfilePhotoAPIAndRoom(token: String): ResourceResult<String> {
+        return try {
+            val result = apiService.deleteProfilePhoto(token)
+            resourceResultDeleteClientProfileImage(result)
         } catch (error: IOException) {
             val message = MessageException("Erro na requisição a api")
-            Log.e(TAG, error.message.toString())
-            return (ResourceResult.Error(null, message))
+            Log.i(TAG, error.message.toString())
+            (ResourceResult.Error(null, message))
         }
 
     }
 
-    private suspend fun Response<String>.resourceResultDeleteProfilePhoto(): ResourceResult<String> {
-        val message = this.code()
-        return if (message == CODE_SUCCESS_204) {
+    private suspend fun resourceResultDeleteClientProfileImage(result: Response<Unit>): ResourceResult<String> {
+        return if (result.code() == CODE_SUCCESS_200) {
             val data = tattooClientProfileDao.getTattooClientProfile()
-            data?.let { tattooClientProfileDao.dellTattooClientProfilePhoto(it.id) }
+            data?.let { tattooClientProfileDao.updateTattooClientProfilePhoto(it.id, "") }
             (ResourceResult.Success("Sucesso ao deletar a foto de perfil"))
         } else {
             val error = MessageException("Foto não encontrada")

--- a/app/src/main/java/br/com/connectattoo/ui/profile/tattoclientditprofile/TattooClientEditProfileDataState.kt
+++ b/app/src/main/java/br/com/connectattoo/ui/profile/tattoclientditprofile/TattooClientEditProfileDataState.kt
@@ -6,5 +6,7 @@ data class TattooClientEditProfileDataState(
     val birthDate: String? = "",
     val imageProfile: String? = "",
     val email: String? = "",
-    val stateError: String? = ""
+    val stateError: String? = "",
+    val stateErrorDeleteImage: String? = "",
+    val messageDeleteImage: String? = ""
 )

--- a/app/src/main/java/br/com/connectattoo/ui/profile/tattoclientditprofile/TattooClientEditProfileFragment.kt
+++ b/app/src/main/java/br/com/connectattoo/ui/profile/tattoclientditprofile/TattooClientEditProfileFragment.kt
@@ -145,13 +145,13 @@ class TattooClientEditProfileFragment : BaseFragment<FragmentTattooClientEditPro
     private fun setupListeners() {
         binding.btnEditClientPhoto.setOnClickListener {
             showBottomSheetEditPhotoProfile(
-
                 onClickChooseLibrary = {
                     Log.i("test", "ChooseLibrary")
                 },
                 onClickTakePicture = {
                     Log.i("test", "TakePicture")
                 },
+                enableBtnRemovePhoto = !viewModel.dataState.imageProfile.isNullOrEmpty(),
                 onClickRemovePhoto = {
                     Log.i("test", "RemovePhoto")
                     removeClientPhoto()

--- a/app/src/main/java/br/com/connectattoo/ui/profile/tattoclientditprofile/TattooClientEditProfileFragment.kt
+++ b/app/src/main/java/br/com/connectattoo/ui/profile/tattoclientditprofile/TattooClientEditProfileFragment.kt
@@ -146,14 +146,13 @@ class TattooClientEditProfileFragment : BaseFragment<FragmentTattooClientEditPro
         binding.btnEditClientPhoto.setOnClickListener {
             showBottomSheetEditPhotoProfile(
                 onClickChooseLibrary = {
-                    Log.i("test", "ChooseLibrary")
+                    Log.i("ChooseLibrary", "ChooseLibrary")
                 },
                 onClickTakePicture = {
-                    Log.i("test", "TakePicture")
+                    Log.i("TakePicture", "TakePicture")
                 },
                 enableBtnRemovePhoto = !viewModel.dataState.imageProfile.isNullOrEmpty(),
                 onClickRemovePhoto = {
-                    Log.i("test", "RemovePhoto")
                     removeClientPhoto()
 
                 }

--- a/app/src/main/java/br/com/connectattoo/ui/profile/tattoclientditprofile/TattooClientEditProfileFragment.kt
+++ b/app/src/main/java/br/com/connectattoo/ui/profile/tattoclientditprofile/TattooClientEditProfileFragment.kt
@@ -17,6 +17,8 @@ import br.com.connectattoo.R
 import br.com.connectattoo.databinding.FragmentTattooClientEditProfileBinding
 import br.com.connectattoo.repository.ProfileRepository
 import br.com.connectattoo.ui.BaseFragment
+import br.com.connectattoo.util.Constants
+import br.com.connectattoo.util.DataStoreManager
 import br.com.connectattoo.util.showBottomSheetEditPhotoProfile
 import com.bumptech.glide.Glide
 import kotlinx.coroutines.launch
@@ -53,6 +55,10 @@ class TattooClientEditProfileFragment : BaseFragment<FragmentTattooClientEditPro
                         }
 
                         TattooClientEditProfileViewModel.UiState.Error -> {
+                            val message = viewModel.dataState.stateErrorDeleteImage
+                            if (message != null) {
+                                Log.i("ErrorDeleteImage", message)
+                            }
                         }
 
                         TattooClientEditProfileViewModel.UiState.Loading -> {
@@ -136,7 +142,7 @@ class TattooClientEditProfileFragment : BaseFragment<FragmentTattooClientEditPro
         }
     }
 
-    private fun setupListeners(){
+    private fun setupListeners() {
         binding.btnEditClientPhoto.setOnClickListener {
             showBottomSheetEditPhotoProfile(
 
@@ -148,9 +154,18 @@ class TattooClientEditProfileFragment : BaseFragment<FragmentTattooClientEditPro
                 },
                 onClickRemovePhoto = {
                     Log.i("test", "RemovePhoto")
+                    removeClientPhoto()
+
                 }
 
             )
+        }
+    }
+
+    private fun removeClientPhoto() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            val token = DataStoreManager.getUserSettings(requireContext(), Constants.API_TOKEN)
+            viewModel.deleteClientProfilePhoto(profileRepository, token)
         }
     }
 

--- a/app/src/main/java/br/com/connectattoo/ui/profile/tattoclientditprofile/TattooClientEditProfileViewModel.kt
+++ b/app/src/main/java/br/com/connectattoo/ui/profile/tattoclientditprofile/TattooClientEditProfileViewModel.kt
@@ -51,6 +51,29 @@ class TattooClientEditProfileViewModel : ViewModel() {
 
     }
 
+    fun deleteClientProfilePhoto(profileRepository: ProfileRepository, token: String) {
+
+        viewModelScope.launch {
+            _uiStateFlow.value = UiState.Loading
+            val result = profileRepository.deleteProfilePhoto(token)
+
+            result.collect {
+                if (it.error != null) {
+                    _dataState =
+                        _dataState.copy(stateErrorDeleteImage = it.error?.message.toString())
+                    _uiStateFlow.value = UiState.Error
+                }
+                it.data?.let { message ->
+                    _dataState = _dataState.copy(
+                        messageDeleteImage = message,
+                        imageProfile = ""
+                    )
+                    _uiStateFlow.value = UiState.Success
+                }
+            }
+        }
+    }
+
     private fun transformBirthDate(birthDate: String?): String? {
         val inputFormat = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
         val outputFormat = SimpleDateFormat("ddMMyyyy", Locale.getDefault())

--- a/app/src/main/java/br/com/connectattoo/util/Constants.kt
+++ b/app/src/main/java/br/com/connectattoo/util/Constants.kt
@@ -3,6 +3,7 @@ package br.com.connectattoo.util
 object Constants {
     const val API_TOKEN = "API_TOKEN"
     const val API_USER_NAME = "USER_NAME"
+    const val CODE_SUCCESS_204 = 204
     const val CODE_ERROR_401 = 401
     const val CODE_ERROR_404 = 404
     const val CODE_ERROR_409 = 409

--- a/app/src/main/java/br/com/connectattoo/util/Constants.kt
+++ b/app/src/main/java/br/com/connectattoo/util/Constants.kt
@@ -3,7 +3,7 @@ package br.com.connectattoo.util
 object Constants {
     const val API_TOKEN = "API_TOKEN"
     const val API_USER_NAME = "USER_NAME"
-    const val CODE_SUCCESS_204 = 204
+    const val CODE_SUCCESS_200 = 200
     const val CODE_ERROR_401 = 401
     const val CODE_ERROR_404 = 404
     const val CODE_ERROR_409 = 409

--- a/app/src/main/java/br/com/connectattoo/util/CustomBottomSheets.kt
+++ b/app/src/main/java/br/com/connectattoo/util/CustomBottomSheets.kt
@@ -10,6 +10,7 @@ fun Fragment.showBottomSheetEditPhotoProfile(
     onClickChooseLibrary: () -> Unit = {},
     onClickTakePicture: () -> Unit = {},
     onClickRemovePhoto: () -> Unit = {},
+    enableBtnRemovePhoto: Boolean = true
 ) {
     val bottomSheetDialog =
         BottomSheetDialog(requireContext(), R.style.ThemeOverlay_App_BottomSheetDialog)
@@ -29,13 +30,15 @@ fun Fragment.showBottomSheetEditPhotoProfile(
     bottomSheetBinding.txtTakePicture.setOnClickListener {
         onClickTakePicture()
     }
-    bottomSheetBinding.ivRemovePhoto.setOnClickListener {
-        onClickRemovePhoto()
-        bottomSheetDialog.dismiss()
-    }
-    bottomSheetBinding.txtRemovePhoto.setOnClickListener {
-        onClickRemovePhoto()
-        bottomSheetDialog.dismiss()
+    if (enableBtnRemovePhoto){
+        bottomSheetBinding.ivRemovePhoto.setOnClickListener {
+            onClickRemovePhoto()
+            bottomSheetDialog.dismiss()
+        }
+        bottomSheetBinding.txtRemovePhoto.setOnClickListener {
+            onClickRemovePhoto()
+            bottomSheetDialog.dismiss()
+        }
     }
 
     bottomSheetDialog.setContentView(bottomSheetBinding.root)

--- a/app/src/main/java/br/com/connectattoo/util/CustomBottomSheets.kt
+++ b/app/src/main/java/br/com/connectattoo/util/CustomBottomSheets.kt
@@ -31,9 +31,11 @@ fun Fragment.showBottomSheetEditPhotoProfile(
     }
     bottomSheetBinding.ivRemovePhoto.setOnClickListener {
         onClickRemovePhoto()
+        bottomSheetDialog.dismiss()
     }
     bottomSheetBinding.txtRemovePhoto.setOnClickListener {
         onClickRemovePhoto()
+        bottomSheetDialog.dismiss()
     }
 
     bottomSheetDialog.setContentView(bottomSheetBinding.root)


### PR DESCRIPTION
### Integrar com API para remoção da foto do perfil

- DELETE foto do perfil do cliente na rota /profile/me/image.
- Passado o token de autenticação no cabeçalho da requisição.
- Removida a URL da foto do perfil do armazenamento local do dispositivo apenas quando recebida uma resposta com código 204 da API.