### PR TITLE
CT-24/CT-156

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -104,6 +104,8 @@ dependencies {
     //Masks
     implementation ("com.github.santalu:maskara:1.0.0")
 
+    //Flexbox
+    implementation ("com.google.android.flexbox:flexbox:3.0.0")
 }
 kapt {
     correctErrorTypes = true

--- a/app/src/main/java/br/com/connectattoo/adapter/AdapterListProfileFilterTags.kt
+++ b/app/src/main/java/br/com/connectattoo/adapter/AdapterListProfileFilterTags.kt
@@ -1,0 +1,70 @@
+package br.com.connectattoo.adapter
+
+import android.graphics.Color
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import br.com.connectattoo.data.Tag
+import br.com.connectattoo.databinding.ItemTagsMyInterestsBinding
+
+class AdapterListProfileFilterTags :
+    ListAdapter<Tag, AdapterListProfileFilterTags.ListTagsProfileViewHolder>(
+        DiffCallbackListProfileFilterTags()
+    ) {
+    var listenerTagProfile: (Tag) -> Unit = {}
+
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ListTagsProfileViewHolder {
+        val inflater = LayoutInflater.from(parent.context)
+        val binding = ItemTagsMyInterestsBinding.inflate(inflater, parent, false)
+
+        return ListTagsProfileViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(holder: ListTagsProfileViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+
+    inner class ListTagsProfileViewHolder(
+        private val binding: ItemTagsMyInterestsBinding
+    ) : RecyclerView.ViewHolder(binding.root) {
+        private var isSelected = false
+        fun bind(tag: Tag) {
+            binding.run {
+
+                btnTagMyInterests.setOnClickListener {
+                    if (isSelected) {
+                        btnTagMyInterests.setBackgroundColor(Color.parseColor("#ebd7ff"))
+                        btnTagMyInterests.setTextColor(Color.parseColor("#460d7d"))
+                        isSelected = false
+                        selectedTags.remove(tag)
+                    } else {
+                        if (selectedTags.size < 5) {
+                            btnTagMyInterests.setBackgroundColor(Color.parseColor("#7A32C1"))
+                            btnTagMyInterests.setTextColor(Color.WHITE)
+                            isSelected = true
+                            selectedTags.add(tag)
+                        }
+                    }
+                    listenerTagProfile(tag)
+                }
+                btnTagMyInterests.text = tag.name
+            }
+        }
+    }
+
+    companion object {
+        private val selectedTags = mutableListOf<Tag>()
+    }
+}
+
+class DiffCallbackListProfileFilterTags : DiffUtil.ItemCallback<Tag>() {
+    override fun areItemsTheSame(oldItem: Tag, newItem: Tag) =
+        oldItem == newItem
+
+    override fun areContentsTheSame(oldItem: Tag, newItem: Tag) =
+        oldItem.id == newItem.id
+
+}

--- a/app/src/main/java/br/com/connectattoo/api/ApiService.kt
+++ b/app/src/main/java/br/com/connectattoo/api/ApiService.kt
@@ -4,6 +4,7 @@ import br.com.connectattoo.api.response.ApiConfirmationResponse
 import br.com.connectattoo.api.response.TattooClientProfileResponse
 import br.com.connectattoo.data.ArtistData
 import br.com.connectattoo.data.ClientData
+import br.com.connectattoo.data.Tag
 import br.com.connectattoo.data.TokenData
 import okhttp3.MultipartBody
 import retrofit2.Call
@@ -55,4 +56,9 @@ interface ApiService {
         @Header("Authorization") authorization: String,
         @Body fields: Map<String, String>
     ) : Response<Unit>
+
+    @GET("tags")
+    suspend fun getAvailableTags(
+        @Header("Authorization") authorization: String
+    ): Response<List<Tag>>
 }

--- a/app/src/main/java/br/com/connectattoo/repository/ProfileRepository.kt
+++ b/app/src/main/java/br/com/connectattoo/repository/ProfileRepository.kt
@@ -6,6 +6,7 @@ import br.com.connectattoo.api.ApiService
 import br.com.connectattoo.api.ApiUrl
 import br.com.connectattoo.core.MessageException
 import br.com.connectattoo.core.ResourceResult
+import br.com.connectattoo.data.Tag
 import br.com.connectattoo.data.TattooClientProfile
 import br.com.connectattoo.local.database.dao.TattooClientProfileDao
 import br.com.connectattoo.utils.Constants.BEARER
@@ -125,5 +126,23 @@ class ProfileRepository(private val tattooClientProfileDao: TattooClientProfileD
             (ResourceResult.Error(null, message))
         }
 
+    }
+
+   suspend fun getAvailableTags(token: String): ResourceResult<List<Tag>>{
+        return try {
+            with(apiService.getAvailableTags("$BEARER $token")){
+                if (this.code() == CODE_SUCCESS_200 || this.code() == CODE_SUCCESS_204) {
+                    (ResourceResult.Success(this.body()))
+                } else {
+                    val error = MessageException("Erro na obtenção das tags")
+                    (ResourceResult.Error(null, error))
+                }
+            }
+
+        } catch (error: IOException) {
+            val message = MessageException("Erro na obtenção das tags: ${error.message}")
+            Log.i(TAG, error.message.toString())
+            (ResourceResult.Error(null, message))
+        }
     }
 }

--- a/app/src/main/java/br/com/connectattoo/ui/profile/tattoclienttagfilter/TattooClientTagsFilterFragment.kt
+++ b/app/src/main/java/br/com/connectattoo/ui/profile/tattoclienttagfilter/TattooClientTagsFilterFragment.kt
@@ -1,0 +1,82 @@
+package br.com.connectattoo.ui.profile.tattoclienttagfilter
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.core.content.ContextCompat
+import androidx.fragment.app.viewModels
+import br.com.connectattoo.R
+import br.com.connectattoo.adapter.AdapterListProfileFilterTags
+import br.com.connectattoo.data.Tag
+import br.com.connectattoo.databinding.FragmentTattooClientTagsFilterBinding
+import br.com.connectattoo.ui.BaseFragment
+import com.google.android.flexbox.FlexDirection
+import com.google.android.flexbox.FlexboxLayoutManager
+import com.google.android.flexbox.JustifyContent
+import com.google.android.material.snackbar.Snackbar
+
+
+class TattooClientTagsFilterFragment : BaseFragment<FragmentTattooClientTagsFilterBinding>() {
+    private lateinit var adapterListTagsProfile: AdapterListProfileFilterTags
+    private val viewModel: TattooClientTagsFilterViewModel by viewModels()
+    override fun setupViews() {
+        setupRecyclerView()
+        setListTags()
+        viewModelObservers()
+    }
+
+    override fun inflateBinding(
+        inflater: LayoutInflater,
+        container: ViewGroup?
+    ): FragmentTattooClientTagsFilterBinding {
+        return FragmentTattooClientTagsFilterBinding.inflate(inflater, container, false)
+    }
+
+    private fun setupRecyclerView() {
+        adapterListTagsProfile = AdapterListProfileFilterTags()
+
+        val layoutManager = FlexboxLayoutManager(requireContext()).apply {
+            flexDirection = FlexDirection.ROW
+            justifyContent = JustifyContent.FLEX_START
+        }
+
+        binding.rvTagsInterests.apply {
+            setHasFixedSize(true)
+            this.layoutManager = layoutManager
+            adapter = adapterListTagsProfile
+        }
+
+        adapterListTagsProfile.listenerTagProfile = { tag ->
+            viewModel.selectTag(tag)
+        }
+
+    }
+
+    private fun viewModelObservers() {
+        viewModel.maximumTagsChecking.observe(viewLifecycleOwner) { checkMaximumTags ->
+            if (checkMaximumTags) {
+                Snackbar.make(
+                    binding.root, getString(
+                        R.string.txt_you_cannot_select_more_than_5_tags
+                    ), Snackbar.LENGTH_LONG
+                )
+                    .setBackgroundTint(
+                        ContextCompat.getColor(requireContext(), R.color.orange)
+                    ).show()
+            }
+        }
+    }
+
+    private fun setListTags() {
+        val list = listOf(
+            Tag(id = "1", name = "Aquarela"),
+            Tag(id = "2", name = "Biomecanica"),
+            Tag(id = "3", name = "caligrafia"),
+            Tag(id = "4", name = "geometrico"),
+            Tag(id = "5", name = "horror"),
+            Tag(id = "6", name = "mandala"),
+            Tag(id = "6", name = "Minimalista"),
+        )
+        adapterListTagsProfile.submitList(list)
+    }
+
+}

--- a/app/src/main/java/br/com/connectattoo/ui/profile/tattoclienttagfilter/TattooClientTagsFilterFragment.kt
+++ b/app/src/main/java/br/com/connectattoo/ui/profile/tattoclienttagfilter/TattooClientTagsFilterFragment.kt
@@ -4,14 +4,12 @@ import android.content.ContentValues.TAG
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.ViewGroup
-import androidx.core.content.ContextCompat
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.fragment.findNavController
 import br.com.connectattoo.ConnectattooApplication
-import br.com.connectattoo.R
 import br.com.connectattoo.adapter.AdapterListProfileFilterTags
 import br.com.connectattoo.databinding.FragmentTattooClientTagsFilterBinding
 import br.com.connectattoo.repository.ProfileRepository
@@ -22,7 +20,6 @@ import br.com.connectattoo.utils.UiState
 import com.google.android.flexbox.FlexDirection
 import com.google.android.flexbox.FlexboxLayoutManager
 import com.google.android.flexbox.JustifyContent
-import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.launch
 
 
@@ -65,18 +62,6 @@ class TattooClientTagsFilterFragment : BaseFragment<FragmentTattooClientTagsFilt
     }
 
     private fun viewModelObservers() {
-        viewModel.maximumTagsChecking.observe(viewLifecycleOwner) { checkMaximumTags ->
-            if (checkMaximumTags) {
-                Snackbar.make(
-                    binding.root, getString(
-                        R.string.txt_you_cannot_select_more_than_5_tags
-                    ), Snackbar.LENGTH_LONG
-                )
-                    .setBackgroundTint(
-                        ContextCompat.getColor(requireContext(), R.color.orange)
-                    ).show()
-            }
-        }
         viewModel.listAvailableTags.observe(viewLifecycleOwner){listTags ->
             if (listTags.isNotEmpty()){
                 adapterListTagsProfile.submitList(listTags)

--- a/app/src/main/java/br/com/connectattoo/ui/profile/tattoclienttagfilter/TattooClientTagsFilterFragment.kt
+++ b/app/src/main/java/br/com/connectattoo/ui/profile/tattoclienttagfilter/TattooClientTagsFilterFragment.kt
@@ -9,6 +9,7 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
+import androidx.navigation.fragment.findNavController
 import br.com.connectattoo.ConnectattooApplication
 import br.com.connectattoo.R
 import br.com.connectattoo.adapter.AdapterListProfileFilterTags
@@ -30,6 +31,7 @@ class TattooClientTagsFilterFragment : BaseFragment<FragmentTattooClientTagsFilt
     private val viewModel: TattooClientTagsFilterViewModel by viewModels()
     private lateinit var profileRepository: ProfileRepository
     override fun setupViews() {
+        setupListeners()
         getAvailableTags()
         setupRecyclerView()
         viewModelObservers()
@@ -106,5 +108,9 @@ class TattooClientTagsFilterFragment : BaseFragment<FragmentTattooClientTagsFilt
             viewModel.getAvailableTags(profileRepository, token)
         }
     }
-
+    private fun setupListeners(){
+        binding.ivBack.setOnClickListener {
+            findNavController().popBackStack()
+        }
+    }
 }

--- a/app/src/main/java/br/com/connectattoo/ui/profile/tattoclienttagfilter/TattooClientTagsFilterViewModel.kt
+++ b/app/src/main/java/br/com/connectattoo/ui/profile/tattoclienttagfilter/TattooClientTagsFilterViewModel.kt
@@ -29,7 +29,7 @@ class TattooClientTagsFilterViewModel : ViewModel() {
         _listTagsSelected.let { listTags ->
             if (listTags.contains(tag)) {
                 listTags.remove(tag)
-            } else if (listTags.count() <= 4) {
+            } else if (listTags.size < 5) {
                 _listTagsSelected.add(tag)
             } else {
                 _maximumTagsChecking.value = true

--- a/app/src/main/java/br/com/connectattoo/ui/profile/tattoclienttagfilter/TattooClientTagsFilterViewModel.kt
+++ b/app/src/main/java/br/com/connectattoo/ui/profile/tattoclienttagfilter/TattooClientTagsFilterViewModel.kt
@@ -1,0 +1,35 @@
+package br.com.connectattoo.ui.profile.tattoclienttagfilter
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import br.com.connectattoo.data.Tag
+import br.com.connectattoo.utils.UiState
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+class TattooClientTagsFilterViewModel : ViewModel() {
+
+    private val _uiStateFlow = MutableStateFlow<UiState>(UiState.Initial)
+    val uiStateFlow: StateFlow<UiState> get() = _uiStateFlow
+
+    private val _listTagsSelected: MutableList<Tag> = mutableListOf()
+
+    private val _maximumTagsChecking = MutableLiveData(false)
+    val maximumTagsChecking: LiveData<Boolean> get() = _maximumTagsChecking
+
+
+    fun selectTag(tag: Tag) {
+        _listTagsSelected.let { listTags ->
+            if (listTags.contains(tag)) {
+                listTags.remove(tag)
+            } else if (listTags.count() <= 4) {
+                _listTagsSelected.add(tag)
+            } else {
+                _maximumTagsChecking.value = true
+            }
+        }
+
+
+    }
+}

--- a/app/src/main/java/br/com/connectattoo/ui/profile/tattoclienttagfilter/TattooClientTagsFilterViewModel.kt
+++ b/app/src/main/java/br/com/connectattoo/ui/profile/tattoclienttagfilter/TattooClientTagsFilterViewModel.kt
@@ -1,5 +1,7 @@
 package br.com.connectattoo.ui.profile.tattoclienttagfilter
 
+import android.content.ContentValues.TAG
+import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -21,9 +23,6 @@ class TattooClientTagsFilterViewModel : ViewModel() {
     private val _listAvailableTags = MutableLiveData <List<Tag>>(mutableListOf())
      val listAvailableTags: LiveData <List<Tag>> = _listAvailableTags
 
-    private val _maximumTagsChecking = MutableLiveData(false)
-    val maximumTagsChecking: LiveData<Boolean> get() = _maximumTagsChecking
-
 
     fun selectTag(tag: Tag) {
         _listTagsSelected.let { listTags ->
@@ -31,8 +30,8 @@ class TattooClientTagsFilterViewModel : ViewModel() {
                 listTags.remove(tag)
             } else if (listTags.size < 5) {
                 _listTagsSelected.add(tag)
-            } else {
-                _maximumTagsChecking.value = true
+            }else{
+                Log.i(TAG, "")
             }
         }
 

--- a/app/src/main/java/br/com/connectattoo/ui/profile/tattoclienttagfilter/TattooClientTagsFilterViewModel.kt
+++ b/app/src/main/java/br/com/connectattoo/ui/profile/tattoclienttagfilter/TattooClientTagsFilterViewModel.kt
@@ -3,10 +3,13 @@ package br.com.connectattoo.ui.profile.tattoclienttagfilter
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import br.com.connectattoo.data.Tag
+import br.com.connectattoo.repository.ProfileRepository
 import br.com.connectattoo.utils.UiState
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
 
 class TattooClientTagsFilterViewModel : ViewModel() {
 
@@ -14,6 +17,9 @@ class TattooClientTagsFilterViewModel : ViewModel() {
     val uiStateFlow: StateFlow<UiState> get() = _uiStateFlow
 
     private val _listTagsSelected: MutableList<Tag> = mutableListOf()
+
+    private val _listAvailableTags = MutableLiveData <List<Tag>>(mutableListOf())
+     val listAvailableTags: LiveData <List<Tag>> = _listAvailableTags
 
     private val _maximumTagsChecking = MutableLiveData(false)
     val maximumTagsChecking: LiveData<Boolean> get() = _maximumTagsChecking
@@ -30,6 +36,24 @@ class TattooClientTagsFilterViewModel : ViewModel() {
             }
         }
 
+    }
+
+    fun getAvailableTags(profileRepository: ProfileRepository, token: String) {
+        _uiStateFlow.value = UiState.Loading
+        viewModelScope.launch {
+            val result = profileRepository.getAvailableTags(token)
+            if (result.error != null) {
+                _uiStateFlow.value = UiState.Error
+            }else if (!result.data.isNullOrEmpty()) {
+                 result.data.let {
+                     _listAvailableTags.value = it
+                 }
+                _uiStateFlow.value = UiState.Success
+            }else{
+                _uiStateFlow.value = UiState.Error
+            }
+
+        }
 
     }
 }

--- a/app/src/main/java/br/com/connectattoo/ui/profile/tattooclient/TattooClientProfileFragment.kt
+++ b/app/src/main/java/br/com/connectattoo/ui/profile/tattooclient/TattooClientProfileFragment.kt
@@ -134,6 +134,7 @@ class TattooClientProfileFragment : BaseFragment<FragmentTattooClientProfileBind
                 findNavController().navigate(R.id.action_clientUserProfileFragment_to_tattooClientEditProfileFragment)
             }
             btnManageInterests.setOnClickListener {
+                findNavController().navigate(R.id.action_clientUserProfileFragment_to_tattoClientTagsFilterFragment)
             }
             btnManageNextAppointment.setOnClickListener {
             }

--- a/app/src/main/java/br/com/connectattoo/utils/UiState.kt
+++ b/app/src/main/java/br/com/connectattoo/utils/UiState.kt
@@ -1,0 +1,8 @@
+package br.com.connectattoo.utils
+
+sealed class UiState {
+    data object Success : UiState()
+    data object Error : UiState()
+    data object Loading : UiState()
+    data object Initial : UiState()
+}

--- a/app/src/main/res/layout/fragment_tattoo_client_tags_filter.xml
+++ b/app/src/main/res/layout/fragment_tattoo_client_tags_filter.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".ui.profile.tattoclientditprofile.TattooClientEditProfileFragment">
+
+
+    <ImageView
+        android:id="@+id/iv_back"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="16dp"
+        android:importantForAccessibility="no"
+        android:src="@drawable/arrow_chevron_left"
+        app:layout_constraintEnd_toStartOf="@+id/txt_edit_profile"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintHorizontal_chainStyle="spread_inside"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/txt_edit_profile"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:fontFamily="@font/raleway_extrabold"
+        android:text="@string/txt_title_filters"
+        android:textColor="@color/black"
+        android:textSize="@dimen/txt_size_20sp"
+        app:layout_constraintBottom_toBottomOf="@+id/iv_back"
+        app:layout_constraintEnd_toStartOf="@+id/iv_logo"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toEndOf="@+id/iv_back"
+        app:layout_constraintTop_toTopOf="@+id/iv_back" />
+
+    <ImageView
+        android:id="@+id/iv_logo"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="16dp"
+        android:importantForAccessibility="no"
+        android:src="@drawable/header_logo_symbol"
+        app:layout_constraintBottom_toBottomOf="@+id/txt_edit_profile"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toEndOf="@+id/txt_edit_profile"
+        app:layout_constraintTop_toTopOf="@+id/txt_edit_profile" />
+
+    <TextView
+        android:id="@+id/txt_Types_of_tattoos"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/margin_16dp"
+        android:layout_marginTop="36dp"
+        android:fontFamily="@font/raleway_extrabold"
+        android:text="@string/txt_types_of_tattoos"
+        android:textColor="@color/black"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/iv_back" />
+
+    <TextView
+        android:id="@+id/txtUpToStyles"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/margin_8dp"
+        android:fontFamily="@font/raleway_regular"
+        android:text="@string/txt_select_up_to_5_styles"
+        android:textColor="@color/black500"
+        android:textSize="@dimen/txt_size_11sp"
+        app:layout_constraintStart_toStartOf="@+id/txt_Types_of_tattoos"
+        app:layout_constraintTop_toBottomOf="@+id/txt_Types_of_tattoos" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/rvTagsInterests"
+        android:layout_width="0dp"
+        android:layout_height="440dp"
+        android:clipToPadding="false"
+        android:orientation="vertical"
+        android:paddingHorizontal="@dimen/margin_8dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/txtUpToStyles"
+        tools:listitem="@layout/item_tags_my_interests" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/btnFilter"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="24dp"
+        android:background="@drawable/bg_cancel_button"
+        android:text="@string/btn_filter"
+        android:layout_marginHorizontal="@dimen/margin_16dp"
+        android:textColor="@color/deepPurple"
+        android:textSize="18sp"
+        android:textStyle="bold"
+        app:backgroundTint="@null"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/rvTagsInterests" />
+
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_tattoo_client_tags_filter.xml
+++ b/app/src/main/res/layout/fragment_tattoo_client_tags_filter.xml
@@ -78,6 +78,7 @@
         android:layout_height="440dp"
         android:clipToPadding="false"
         android:orientation="vertical"
+        android:paddingTop="@dimen/margin_16dp"
         android:paddingHorizontal="@dimen/margin_8dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/navigation/user_page_navigation_graph.xml
+++ b/app/src/main/res/navigation/user_page_navigation_graph.xml
@@ -19,6 +19,9 @@
             android:id="@+id/action_clientUserProfileFragment_to_tattooClientEditProfileFragment"
             app:destination="@id/tattooClientEditProfileFragment"
             app:enterAnim="@anim/slide_in_rigth" />
+        <action
+            android:id="@+id/action_clientUserProfileFragment_to_tattoClientTagsFilterFragment"
+            app:destination="@id/tattoClientTagsFilterFragment" />
     </fragment>
     <fragment
         android:id="@+id/tattooClientEditProfileFragment"
@@ -40,4 +43,9 @@
         android:name="br.com.connectattoo.ui.search.UserSearchFragment"
         android:label="fragment_user_search"
         tools:layout="@layout/fragment_user_search" />
+    <fragment
+        android:id="@+id/tattoClientTagsFilterFragment"
+        android:name="br.com.connectattoo.ui.profile.tattoclienttagfilter.TattooClientTagsFilterFragment"
+        android:label="fragment_tatto_client_tags_filter"
+        tools:layout="@layout/fragment_tattoo_client_tags_filter" />
 </navigation>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -43,4 +43,9 @@
     <string name="cancel">Cancelar</string>
     <string name="snack_photo_size_exceeds_5MB">O tamanho da foto excede 5MB</string>
     <string name="snack_please_select_an_image_in_JPEG_JPG_or_PNG_format">Por favor, selecione uma imagem nos formatos JPEG, JPG ou PNG</string>
+    <string name="txt_title_filters">Filtros</string>
+    <string name="txt_types_of_tattoos">Tipos de Tatuagem</string>
+    <string name="txt_select_up_to_5_styles">Selecione até 5 estilos</string>
+    <string name="btn_filter">Filtrar</string>
+    <string name="txt_you_cannot_select_more_than_5_tags">"Você não pode selecionar mais do que 5 tags."</string>
 </resources>


### PR DESCRIPTION
### Criar tela de filtros para tags de usuário
- Implementado biblioteca do google para listas de tamanhos dinâmicos a serem exibidas na recyclerView.
- Implementada a tela de filtros para tags do usuário seguindo os layouts fornecidos no Figma e Zeplin.
- Adicionada a navegação para a tela de filtros ao clicar em "Gerenciar" na tela de "Perfil -> "Meus interesses".
- Adicionada a ação de seleção de tags ao clicar em qualquer tag.
- Limitado a seleção em até 5 tags.
- Integrado com a API para a listagem de tags de tatuagens disponíveis.
- Realizada uma chamada GET para /tags para obter todas as tags de tatuagens disponíveis.
- Passado o token de autenticação no cabeçalho da requisição. A resposta será uma lista de tags de tatuagens disponíveis e código de status 200.